### PR TITLE
update oversampler base.py

### DIFF
--- a/imblearn/over_sampling/base.py
+++ b/imblearn/over_sampling/base.py
@@ -61,7 +61,7 @@ class BaseOverSampler(BaseSampler):
     _parameter_constraints: dict = {
         "sampling_strategy": [
             Interval(numbers.Real, 0, 1, closed="right"),
-            StrOptions({"auto", "majority", "not minority", "not majority", "all"}),
+            StrOptions({"auto", "minority", "not minority", "not majority", "all"}),
             Mapping,
             callable,
         ],


### PR DESCRIPTION
updated majority to minority  in str options:  
_parameter_constraints: dict = {
        "sampling_strategy": [
            Interval(numbers.Real, 0, 1, closed="right"),
            StrOptions({"auto", "minority", "not minority", "not majority", "all"}),
            Mapping,
            callable,
        ],
        "random_state": ["random_state"],
    }

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
I think mistake with recent update for sampling strategy of oversampler in smote.
majority mentioned in place of minority

#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
